### PR TITLE
DOC: fix typo in mimize docs

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -96,7 +96,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
         where ``x`` is an array with shape (n,) and ``args`` is a tuple with
         the fixed parameters. If `jac` is a Boolean and is True, `fun` is
-        assumed to return and objective and gradient as an ``(f, g)`` tuple.
+        assumed to return an objective and gradient as a ``(f, g)`` tuple.
         Methods 'Newton-CG', 'trust-ncg', 'dogleg', 'trust-exact', and
         'trust-krylov' require that either a callable be supplied, or that
         `fun` return the objective and gradient.


### PR DESCRIPTION
Fixes a small typo in the minimize docs.